### PR TITLE
Dialga and Palkia fix

### DIFF
--- a/Constants.py
+++ b/Constants.py
@@ -91,7 +91,7 @@ WILD_WALKING_DIRECTION = 'EW'
 MOVE_FORWARD_STATIC_ENCOUNTER = False
 SKIP_UPDATING_GAME = False
 # Some static encounters make a white screen flash before entering the combat
-# Raise this value to 5 for Dialga and Palkia; default value is 2
+# Raise this value to 4 for Dialga and Palkia; default value is 2
 STATIC_ENCOUNTERS_DELAY = 2
 # How long has the bot been stuck in the same state before restarting the game
 STUCK_TIMER_SECONDS = 30

--- a/Constants.py
+++ b/Constants.py
@@ -90,6 +90,9 @@ WILD_WALKING_SECONDS = 1
 WILD_WALKING_DIRECTION = 'EW'
 MOVE_FORWARD_STATIC_ENCOUNTER = False
 SKIP_UPDATING_GAME = False
+# Some static encounters make a white screen flash before entering the combat
+# Raise this value to 5 for Dialga and Palkia; default value is 2
+STATIC_ENCOUNTERS_DELAY = 2
 # How long has the bot been stuck in the same state before restarting the game
 STUCK_TIMER_SECONDS = 30
 SHINY_DETECTION_TIME = 2

--- a/Modules/Control_System.py
+++ b/Modules/Control_System.py
@@ -173,7 +173,7 @@ def static_encounter(image, state):
 
     # Game loaded, player in the overworld
     # Some static encounters make a white screen flash before entering the combat
-    elif state == 'ENTER_STATIC_COMBAT_3' and time() - state_timer >= 2:
+    elif state == 'ENTER_STATIC_COMBAT_3' and time() - state_timer >= CONST.STATIC_ENCOUNTERS_DELAY:
         # Look for the load combat white screen
         if image.check_multiple_pixel_colors(
             [CONST.TEXT_BOX_LINE['x'], CONST.TEXT_BOX_LINE['y1']],


### PR DESCRIPTION
The app crash for Palkia shiny hunt.
We enter in CHECK_SHINY too early and the app fail to recognize the pokemon name since we are still in the start animation.
Exception in `pokemon_image.recognize_pokemon()`

It appears that the delay of 2 seconds is not enough for Palkia fights (I assume it's the same for Dialga).
The white screen make more than 2 seconds to appears.
With a delay of 4 or 5 the app does not crash anymore and look like it's working (currently hunting).
