### PR TITLE
Fix Regigigas hunt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__
 .venv/
 .vscode/
+.idea/
 .pytest_cache
 
 /Media/Tests/

--- a/Constants.py
+++ b/Constants.py
@@ -100,7 +100,7 @@ SKIP_UPDATING_GAME = False
 # - Dialga and Palkia: 4
 # - Arceus: 6.5
 # - Uxie: 3
-# - Regigigas: 5.5
+# - Regigigas: 7
 STATIC_ENCOUNTERS_DELAY = 2
 
 # How long has the bot been stuck in the same state before restarting the game

--- a/Constants.py
+++ b/Constants.py
@@ -94,9 +94,15 @@ WILD_WALKING_SECONDS = 1
 WILD_WALKING_DIRECTION = 'NS'
 MOVE_FORWARD_STATIC_ENCOUNTER = False
 SKIP_UPDATING_GAME = False
-# Some static encounters make a white screen flash before entering the combat
-# Raise this value to 4 for Dialga and Palkia, 6.5 for Arceus; default value is 2
+
+# Variable used to skip a white screen flash (some static encounters have two white screen flashes)
+# - Default value is 2
+# - Dialga and Palkia: 4
+# - Arceus: 6.5
+# - Uxie: 3
+# - Regigigas: 5.5
 STATIC_ENCOUNTERS_DELAY = 2
+
 # How long has the bot been stuck in the same state before restarting the game
 STUCK_TIMER_SECONDS = 30
 SHINY_DETECTION_TIME = 2.5

--- a/Shiny_Hunter.py
+++ b/Shiny_Hunter.py
@@ -225,10 +225,15 @@ def controller_control(controller, shutdown_event):
         # Prevent the main execution from being blocked
         with controller.event_lock: aux_current_event = controller.current_event
 
+        # Macros that require A button press
+        # ENTER_STATIC_COMBAT_3 needs to press A to enter the combat for Regigigas, it has two dialog phases.
+        need_to_press_a_states = ['RESTART_GAME_2', 'RESTART_GAME_3', 'ENTER_STATIC_COMBAT_2', 'ENTER_STATIC_COMBAT_3',
+                  'ESCAPE_FAILED_2', 'ENTER_LAKE_2', 'ENTER_LAKE_4']
+
         if aux_current_event == 'WAIT_HOME_SCREEN': fast_start_macro(controller)
         elif aux_current_event == 'RESTART_GAME_1': restart_game_macro(controller)
-        elif aux_current_event in ['RESTART_GAME_2', 'RESTART_GAME_3', 'ENTER_STATIC_COMBAT_2', 
-            'ESCAPE_FAILED_2', 'ENTER_LAKE_2', 'ENTER_LAKE_4']: press_single_button(controller, 'A')
+
+        elif aux_current_event in need_to_press_a_states: press_single_button(controller, 'A')
         elif aux_current_event == 'ENTER_STATIC_COMBAT_1': enter_static_combat_macro(controller)
         elif aux_current_event == 'MOVE_PLAYER': move_player_wild_macro(controller)
         elif aux_current_event == 'ENTER_LAKE_1': enter_lake_macro(controller)

--- a/Shiny_Hunter.py
+++ b/Shiny_Hunter.py
@@ -232,7 +232,6 @@ def controller_control(controller, shutdown_event):
 
         if aux_current_event == 'WAIT_HOME_SCREEN': fast_start_macro(controller)
         elif aux_current_event == 'RESTART_GAME_1': restart_game_macro(controller)
-
         elif aux_current_event in need_to_press_a_states: press_single_button(controller, 'A')
         elif aux_current_event == 'ENTER_STATIC_COMBAT_1': enter_static_combat_macro(controller)
         elif aux_current_event == 'MOVE_PLAYER': move_player_wild_macro(controller)


### PR DESCRIPTION
Regigigas has 2 dialog phases which implies we get stuck waiting for the white screen in phase ENTER_STATIC_COMBAT_3.

To fix that, the A button is pressed during the phase ENTER_STATIC_COMBAT_3.
Also, the delay for Regigigas needs to be set to 5.5.

In this MR the delay comments also include the value to hunt Uxie (3s).
