### PR TITLE
Fix regression on restart black screen test

### DIFF
--- a/Modules/Control_System.py
+++ b/Modules/Control_System.py
@@ -118,7 +118,8 @@ def static_encounter(image, state):
     # Game loading, full black screen
     elif state == 'RESTART_GAME_4':
         # Check if the black screen has ended
-        if not is_black_screen_visible(image):
+        # is_black_screen_visible can't be used due to the loading Pokémon sprites
+        if not is_life_box_visible(image, CONST.LOAD_SCREEN_BLACK_COLOR):
             return 'ENTER_STATIC_COMBAT_1'
 
     # Game loaded, player in the overworld
@@ -171,7 +172,8 @@ def starter_encounter(image, state):
 
     elif state == 'RESTART_GAME_4':
         # Check if the black screen has ended
-        if not is_black_screen_visible(image):
+        # is_black_screen_visible can't be used due to the loading Pokémon sprites
+        if not is_life_box_visible(image, CONST.LOAD_SCREEN_BLACK_COLOR):
             return 'ENTER_LAKE_1'
 
     # In front of the lake entrance
@@ -293,7 +295,8 @@ def shaymin_encounter(image, state):
     # Game loading, full black screen
     elif state == 'RESTART_GAME_4':
         # Check if the black screen has ended
-        if not is_black_screen_visible(image):
+        # is_black_screen_visible can't be used due to the loading Pokémon sprites
+        if not is_life_box_visible(image, CONST.LOAD_SCREEN_BLACK_COLOR):
             return 'ENTER_STATIC_COMBAT_1'
 
     # Combat loaded (Wild Pokémon stars)
@@ -378,17 +381,20 @@ def _check_common_states(image, state):
 
     # Nintendo Switch main menu
     elif state == 'RESTART_GAME_1':
-        if is_black_screen_visible(image):
+        # is_black_screen_visible can't be used due to the loading Nintendo Switch logo
+        if is_life_box_visible(image, CONST.LOAD_SCREEN_BLACK_COLOR):
             return 'RESTART_GAME_2'
 
     # Game main loadscreen (Full black screen)
     elif state == 'RESTART_GAME_2':
-        if not is_black_screen_visible(image):
+        # is_black_screen_visible can't be used due to the loading Nintendo logo
+        if not is_life_box_visible(image, CONST.LOAD_SCREEN_BLACK_COLOR):
             return 'RESTART_GAME_3'
 
     # Game main loadscreen (Dialga / Palkia)
     elif state == 'RESTART_GAME_3':
-        if is_black_screen_visible(image):
+        # is_black_screen_visible can't be used due to the loading Pokémon sprites
+        if is_life_box_visible(image, CONST.LOAD_SCREEN_BLACK_COLOR):
             return 'RESTART_GAME_4'
 
     # Combat loadscreen (Full white screen)

--- a/Modules/Image_Processing.py
+++ b/Modules/Image_Processing.py
@@ -257,8 +257,7 @@ if __name__ == "__main__":
         print(COLOR_str.MENU_OPTION.replace('{index}', '4').replace('{option}', 'Check lost shiny'))
         print(COLOR_str.MENU_OPTION.replace('{index}', '5').replace('{option}', 'Test debug video frame'))
 
-        # option = input('\n' + COLOR_str.OPTION_SELECTION.replace('{module}', 'Image Processing'))
-        option = '5'
+        option = input('\n' + COLOR_str.OPTION_SELECTION.replace('{module}', 'Image Processing'))
 
         menu_options = {
             '1': process_image,


### PR DESCRIPTION
There are 2 Nintendo logos (top left and bottom right) and the Pokémon sprites (bottom right) that conflict with the is_black_screen_visible

![image](https://github.com/user-attachments/assets/00403dcd-61d3-4e5f-b4f5-7766d4f28ea1)
![image](https://github.com/user-attachments/assets/7334ea04-8e59-4e3d-a1d6-a8eb2b95c95b)
