### PR TITLE
Implement a more precise screen checking

### DIFF
--- a/Constants.py
+++ b/Constants.py
@@ -116,28 +116,41 @@ HOME_MENU_COLOR = (237, 237, 237)
 PAIRING_MENU_COLOR = (135, 135, 125)
 LOAD_SCREEN_BLACK_COLOR = (5, 5, 5)
 TEXT_BOX_LINE = {
-    'x': int(MAIN_FRAME_SIZE[0] // 16 * 1.2),
-    'y1': int(MAIN_FRAME_SIZE[1] // 16 * 1),
-    'y2': int(MAIN_FRAME_SIZE[1] // 16 * 2), 
-    # [BGR]
-    'color': (250, 250, 250),
-    'overworld_x': int(MAIN_FRAME_SIZE[0] // 16 * 3.5),
+    'left_white': (int(MAIN_FRAME_SIZE[0] // 16 * 1.2), int(MAIN_FRAME_SIZE[1] // 16 * 1)),
+    'right_white': (MAIN_FRAME_SIZE[0] - int(MAIN_FRAME_SIZE[0] // 16 * 1.2), int(MAIN_FRAME_SIZE[1] // 16 * 1)),
+    'overworld': (int(MAIN_FRAME_SIZE[0] // 16 * 3.5), int(MAIN_FRAME_SIZE[1] // 16 * 1)),
+    'border_left_x': 34,
+    'border_color': (74, 81, 73),
+    'border_color_threshold': 10
 }
 LIFE_BOX_LINE = {
-    'x': int(MAIN_FRAME_SIZE[0] // 96 * 1),
-    'y1': int(MAIN_FRAME_SIZE[1] // 16 * 2),
-    'y2': int(MAIN_FRAME_SIZE[1] // 16 * 2.6),
-    # [BGR]
-    'color': (250, 250, 250)
+    'position': (
+        int(MAIN_FRAME_SIZE[0] // 96 * 1),
+        int(MAIN_FRAME_SIZE[1] // 16 * 2)
+    ),
+    'column_height': 15,
 }
 SELECTION_BOX_LINE = {
-    'x': int(MAIN_FRAME_SIZE[0] // 16 * 13),
-    'y1': int(MAIN_FRAME_SIZE[1] // 16 * 4),
-    'y2': int(MAIN_FRAME_SIZE[1] // 16 * 5),
-    # [BGR]
-    'color': (250, 250, 250)
+    'position': (
+        int(MAIN_FRAME_SIZE[0] // 16 * 13),
+        int(MAIN_FRAME_SIZE[1] // 16 * 4)
+    ),
 }
-# 'L': Left | 'C': Center | 'R': Right 
+COLOR_SCREEN_CHECK = {
+    'top_left': (50, MAIN_FRAME_SIZE[1] - 50),
+    'center_left': (50, MAIN_FRAME_SIZE[1] // 2 - 25),
+    'bottom_left': (50, 25),
+    'top_right': (MAIN_FRAME_SIZE[0] - 50, MAIN_FRAME_SIZE[1] - 50),
+    'center_right': (MAIN_FRAME_SIZE[0] - 50, MAIN_FRAME_SIZE[1] // 2 - 25),
+    'bottom_right': (MAIN_FRAME_SIZE[0] - 50, 25),
+    'center': (MAIN_FRAME_SIZE[0] // 2 - 25, MAIN_FRAME_SIZE[1] // 2 - 25),
+    'column_height': 25,
+    # [BGR]
+    'black_color': (5, 5, 5),
+    'white_color': (250, 250, 250)
+}
+
+# 'L': Left | 'C': Center | 'R': Right
 STARTER = 'R'
 
 ###########################################################################################################################

--- a/Modules/Control_System.py
+++ b/Modules/Control_System.py
@@ -39,7 +39,7 @@ def search_wild_pokemon(image, state):
     # Game loaded, player in the overworld
     elif state == 'MOVE_PLAYER':
         # Look for the load combat white screen
-        if is_load_fight_white_screen_visible(image):
+        if is_white_screen_visible(image):
             state_timer = time()
             return 'ENTER_COMBAT_1'
 
@@ -118,8 +118,7 @@ def static_encounter(image, state):
     # Game loading, full black screen
     elif state == 'RESTART_GAME_4':
         # Check if the black screen has ended
-        # is_black_screen_visible can't be used due to the loading Pokémon sprites
-        if not is_life_box_visible(image, CONST.LOAD_SCREEN_BLACK_COLOR):
+        if not is_bdsp_loading_screen(image):
             return 'ENTER_STATIC_COMBAT_1'
 
     # Game loaded, player in the overworld
@@ -139,7 +138,7 @@ def static_encounter(image, state):
     # Some static encounters make a white screen flash before entering the combat
     elif state == 'ENTER_STATIC_COMBAT_3' and time() - state_timer >= CONST.STATIC_ENCOUNTERS_DELAY:
         # Look for the load combat white screen
-        if is_load_fight_white_screen_visible(image):
+        if is_white_screen_visible(image):
             state_timer = time()
             return 'ENTER_COMBAT_1'
 
@@ -172,8 +171,7 @@ def starter_encounter(image, state):
 
     elif state == 'RESTART_GAME_4':
         # Check if the black screen has ended
-        # is_black_screen_visible can't be used due to the loading Pokémon sprites
-        if not is_life_box_visible(image, CONST.LOAD_SCREEN_BLACK_COLOR):
+        if not is_bdsp_loading_screen(image):
             return 'ENTER_LAKE_1'
 
     # In front of the lake entrance
@@ -209,9 +207,9 @@ def starter_encounter(image, state):
     # Briefcase is opened
     elif state == 'STARTER_SELECTION_2':
         # Look for the selection box: (Yes/No)
-        if image.check_multiple_pixel_colors(
-            [CONST.SELECTION_BOX_LINE['x'], CONST.SELECTION_BOX_LINE['y1']],
-            [CONST.SELECTION_BOX_LINE['x'], CONST.SELECTION_BOX_LINE['y2']], CONST.SELECTION_BOX_LINE['color']
+        if image.check_column_pixel_colors(
+            CONST.SELECTION_BOX_LINE['position'],
+            CONST.COLOR_SCREEN_CHECK['column_height'], CONST.COLOR_SCREEN_CHECK['white_color']
         ):
             return 'STARTER_SELECTION_3'
 
@@ -288,15 +286,14 @@ def shaymin_encounter(image, state):
     # Some static encounters make a white screen flash before entering the combat
     elif state == 'ENTER_STATIC_COMBAT_3' and time() - state_timer >= CONST.STATIC_ENCOUNTERS_DELAY:
         # Look for the load combat white screen
-        if is_load_fight_white_screen_visible(image):
+        if is_white_screen_visible(image):
             state_timer = time()
             return 'ENTER_COMBAT_1'
     
     # Game loading, full black screen
     elif state == 'RESTART_GAME_4':
         # Check if the black screen has ended
-        # is_black_screen_visible can't be used due to the loading Pokémon sprites
-        if not is_life_box_visible(image, CONST.LOAD_SCREEN_BLACK_COLOR):
+        if not is_bdsp_loading_screen(image):
             return 'ENTER_STATIC_COMBAT_1'
 
     # Combat loaded (Wild Pokémon stars)
@@ -381,27 +378,24 @@ def _check_common_states(image, state):
 
     # Nintendo Switch main menu
     elif state == 'RESTART_GAME_1':
-        # is_black_screen_visible can't be used due to the loading Nintendo Switch logo
-        if is_life_box_visible(image, CONST.LOAD_SCREEN_BLACK_COLOR):
+        if is_bdsp_loading_screen(image):
             return 'RESTART_GAME_2'
 
     # Game main loadscreen (Full black screen)
     elif state == 'RESTART_GAME_2':
-        # is_black_screen_visible can't be used due to the loading Nintendo logo
-        if not is_life_box_visible(image, CONST.LOAD_SCREEN_BLACK_COLOR):
+        if not is_bdsp_loading_screen(image):
             return 'RESTART_GAME_3'
 
     # Game main loadscreen (Dialga / Palkia)
     elif state == 'RESTART_GAME_3':
-        # is_black_screen_visible can't be used due to the loading Pokémon sprites
-        if is_life_box_visible(image, CONST.LOAD_SCREEN_BLACK_COLOR):
+        if is_bdsp_loading_screen(image):
             return 'RESTART_GAME_4'
 
     # Combat loadscreen (Full white screen)
     # Some wild encounters missdetect this state with the grass animation
     elif state == 'ENTER_COMBAT_1' and time() - state_timer >= 0.5:
         # Check if the white load screen has ended
-        if not is_load_fight_white_screen_visible(image):
+        if not is_white_screen_visible(image):
             return 'ENTER_COMBAT_2'
 
     # Combat loadscreen (Grass/Rock/Water animation, wild pokémon appearing)
@@ -427,19 +421,112 @@ def _check_common_states(image, state):
 ###########################################################################################################################
 ###########################################################################################################################
 
-def is_life_box_visible(image, color=CONST.LIFE_BOX_LINE['color']):
+def is_bdsp_loading_screen(image):
+    """
+    Checks if the given image matches the BDSP loading screen by verifying specific color positions.
+
+    BDSP loading screen has a black background.
+    The top-left may have the Nintendo logo.
+    The bottom-right may have the Nintendo Switch logo or the Pokémon starters icons.
+    The center may have the Nintendo copyright texts.
+
+    Args:
+        image: The image to be checked.
+
+    Returns:
+        bool: True if the image matches the BDSP loading screen, False otherwise.
+    """
+    return check_image_position_colors(
+        image,
+        CONST.COLOR_SCREEN_CHECK['black_color'],
+        [
+            CONST.COLOR_SCREEN_CHECK['top_right'],
+            CONST.COLOR_SCREEN_CHECK['center_left'],
+            CONST.COLOR_SCREEN_CHECK['center_right'],
+            CONST.COLOR_SCREEN_CHECK['bottom_left']
+        ]
+    )
+
+
+def is_single_color(image, color):
+    """
+    Checks if image is of a single color.
+
+    The image is considered to be of a single color if
+    specific positions in the image are of the given color.
+    The checked positions are the top-left, top-right, center, bottom-left, and bottom-right.
+
+    Args:
+        image (Image): The image to be checked.
+        color (tuple): The color to check for.
+
+    Returns:
+        bool: True if all specified positions in the image are of the given color, False otherwise.
+    """
+    return check_image_position_colors(
+        image,
+        color,
+        [
+            CONST.COLOR_SCREEN_CHECK['top_left'],
+            CONST.COLOR_SCREEN_CHECK['top_right'],
+            CONST.COLOR_SCREEN_CHECK['center'],
+            CONST.COLOR_SCREEN_CHECK['bottom_left'],
+            CONST.COLOR_SCREEN_CHECK['bottom_right']
+        ]
+    )
+
+
+def check_image_position_colors(image, color, positions):
+    """
+    Checks if the specified color is present at the given positions in the image.
+
+    Args:
+        image: The image to check.
+        color: The color to check for at the specified positions.
+        positions: A list of positions (coordinates) to check in the image.
+
+    Returns:
+        bool: True if the specified color is present at all given positions, False otherwise.
+    """
+    for position in positions:
+        if not image.check_column_pixel_colors(position, CONST.COLOR_SCREEN_CHECK['column_height'], color):
+            return False
+    return True
+
+
+def is_life_box_visible(image):
     """
     Checks if the life box is visible in the given image.
+    The life box is considered visible if the life box content is white
+    and the area outside the life box content is not white.
+    
     Args:
         image: The image in which to check for the life box.
         color: The color of the life box.
     Returns:
         bool: True if the life box is visible, False otherwise.
     """
-    return image.check_multiple_pixel_colors(
-        [CONST.LIFE_BOX_LINE['x'], CONST.LIFE_BOX_LINE['y1']],
-        [CONST.LIFE_BOX_LINE['x'], CONST.LIFE_BOX_LINE['y2']], color
+
+    is_life_box_content_white = image.check_column_pixel_colors(CONST.LIFE_BOX_LINE['position'], CONST.LIFE_BOX_LINE['column_height'],
+                                             CONST.COLOR_SCREEN_CHECK['white_color'])
+
+    if not is_life_box_content_white:
+        # Stop testing if the text box content is not white
+        return False
+
+
+    is_outside_life_box_not_white = check_image_position_colors(
+        image,
+        CONST.COLOR_SCREEN_CHECK['white_color'],
+        [
+            CONST.COLOR_SCREEN_CHECK['top_left'],
+            CONST.COLOR_SCREEN_CHECK['center_left'],
+            CONST.COLOR_SCREEN_CHECK['center'],
+            CONST.COLOR_SCREEN_CHECK['bottom_right'],
+        ]
     )
+
+    return not is_outside_life_box_not_white
 
 ###########################################################################################################################
 
@@ -451,30 +538,46 @@ def is_black_screen_visible(image):
     Returns:
         bool: True if the black screen is visible, False otherwise.
     """
-    return is_load_fight_white_screen_visible(image, CONST.LOAD_SCREEN_BLACK_COLOR)
+    return is_single_color(image, CONST.LOAD_SCREEN_BLACK_COLOR)
 
 ###########################################################################################################################
 
 def is_text_box_visible(image):
     """
     Checks if the text box is visible in the given image.
+    The text box is considered visible if the text box content is white
+    and the area outside the text box content is not white.
+
     Args:
         image: The image in which to check for the text box.
-        x: The x coordinate of the text box.
     Returns:
         bool: True if the text box is visible, False otherwise.
     """
-    text_box_left_visible = image.check_multiple_pixel_colors(
-        [CONST.TEXT_BOX_LINE['x'], CONST.TEXT_BOX_LINE['y1']],
-        [CONST.TEXT_BOX_LINE['x'], CONST.TEXT_BOX_LINE['y2']],
-        CONST.TEXT_BOX_LINE['color'])
 
-    text_box_right_visible = image.check_multiple_pixel_colors(
-        [CONST.MAIN_FRAME_SIZE[0] - CONST.TEXT_BOX_LINE['x'], CONST.TEXT_BOX_LINE['y1']],
-        [CONST.MAIN_FRAME_SIZE[0] - CONST.TEXT_BOX_LINE['x'], CONST.TEXT_BOX_LINE['y2']],
-        CONST.TEXT_BOX_LINE['color'])
+    is_text_box_content_white = check_image_position_colors(
+        image,
+        CONST.COLOR_SCREEN_CHECK['white_color'],
+        [
+            CONST.TEXT_BOX_LINE['left_white'],
+            CONST.TEXT_BOX_LINE['right_white']
+        ]
+    )
 
-    return text_box_left_visible and text_box_right_visible
+    if not is_text_box_content_white:
+        # Stop testing if the text box content is not white
+        return False
+
+    is_outside_text_box_not_white = check_image_position_colors(
+        image,
+        CONST.COLOR_SCREEN_CHECK['white_color'],
+        [
+            CONST.COLOR_SCREEN_CHECK['top_left'],
+            CONST.COLOR_SCREEN_CHECK['top_right'],
+            CONST.COLOR_SCREEN_CHECK['center'],
+        ]
+    )
+
+    return not is_outside_text_box_not_white
 
 ###########################################################################################################################
 
@@ -486,14 +589,15 @@ def is_overworld_visible(image):
     Returns:
         bool: True if the overworld is visible, False otherwise.
     """
-    return image.check_multiple_pixel_colors(
-        [CONST.TEXT_BOX_LINE['overworld_x'], CONST.TEXT_BOX_LINE['y1']],
-        [CONST.TEXT_BOX_LINE['overworld_x'], CONST.TEXT_BOX_LINE['y2']], CONST.TEXT_BOX_LINE['color']
+    return image.check_column_pixel_colors(
+        CONST.TEXT_BOX_LINE['overworld'],
+        CONST.COLOR_SCREEN_CHECK['column_height'],
+        CONST.COLOR_SCREEN_CHECK['white_color']
     )
 
 ###########################################################################################################################
 
-def is_load_fight_white_screen_visible(image, color=CONST.TEXT_BOX_LINE['color']):
+def is_white_screen_visible(image):
     """
     Checks if the white screen is visible in the given image.
     Args:
@@ -501,27 +605,7 @@ def is_load_fight_white_screen_visible(image, color=CONST.TEXT_BOX_LINE['color']
     Returns:
         bool: True if the white screen is visible, False otherwise.
     """
-    is_bottom_left_white = image.check_multiple_pixel_colors(
-        [CONST.TEXT_BOX_LINE['x'], CONST.TEXT_BOX_LINE['y1']],
-        [CONST.TEXT_BOX_LINE['x'], CONST.TEXT_BOX_LINE['y2']],
-        color)
-
-    is_bottom_right_white = image.check_multiple_pixel_colors(
-        [CONST.MAIN_FRAME_SIZE[0] - CONST.TEXT_BOX_LINE['x'], CONST.TEXT_BOX_LINE['y1']],
-        [CONST.MAIN_FRAME_SIZE[0] - CONST.TEXT_BOX_LINE['x'], CONST.TEXT_BOX_LINE['y2']],
-        color)
-
-    is_top_left_white = image.check_multiple_pixel_colors(
-        [CONST.TEXT_BOX_LINE['x'], CONST.MAIN_FRAME_SIZE[1] - CONST.TEXT_BOX_LINE['y2']],
-        [CONST.TEXT_BOX_LINE['x'], CONST.MAIN_FRAME_SIZE[1] - CONST.TEXT_BOX_LINE['y1']],
-        color)
-
-    is_top_right_white = image.check_multiple_pixel_colors(
-        [CONST.MAIN_FRAME_SIZE[0] - CONST.TEXT_BOX_LINE['x'], CONST.MAIN_FRAME_SIZE[1] - CONST.TEXT_BOX_LINE['y2']],
-        [CONST.MAIN_FRAME_SIZE[0] - CONST.TEXT_BOX_LINE['x'], CONST.MAIN_FRAME_SIZE[1] - CONST.TEXT_BOX_LINE['y1']],
-        color)
-
-    return is_bottom_left_white and is_bottom_right_white and is_top_left_white and is_top_right_white
+    return is_single_color(image, CONST.COLOR_SCREEN_CHECK['white_color'])
 
 ###########################################################################################################################
 #####################################################     PROGRAM     #####################################################

--- a/Modules/Image_Processing.py
+++ b/Modules/Image_Processing.py
@@ -5,6 +5,7 @@
 # Set the cwd to the one of the file
 import os
 import logging
+from typing import Tuple
 
 if __name__ == '__main__':
     try: os.chdir(os.path.dirname(__file__))
@@ -16,7 +17,8 @@ import numpy as np
 from time import time, perf_counter
 import PyQt5.QtGui as pyqt_g
 
-import sys; sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import Colored_Strings as COLOR_str
 import Constants as CONST
 
@@ -64,22 +66,26 @@ class Image_Processing():
 
     #######################################################################################################################
 
-    # Draw FPS at the top-left corner
-    def draw_FPS(self, FPS = 0):
+    # Ensure FPS image is initialized
+    def _ensure_fps_image(self):
         if isinstance(self.FPS_image, type(None)):
             # Without copy() method, images would be linked, meaning that modifying one image would also alter the other
             self.FPS_image = np.copy(self.resized_image)
+
+    #######################################################################################################################
+
+    # Draw FPS at the top-left corner
+    def draw_FPS(self, FPS = 0):
+        self._ensure_fps_image()
 
         cv2.putText(self.FPS_image, f'FPS: {FPS}', CONST.TEXT_PARAMS['position'], cv2.FONT_HERSHEY_SIMPLEX,
             CONST.TEXT_PARAMS['font_scale'], CONST.TEXT_PARAMS['font_color'], CONST.TEXT_PARAMS['thickness'], cv2.LINE_AA)
 
     #######################################################################################################################
 
-    # Write the spcified at the top-left corner
+    # Write the specified text at the top-left corner
     def write_text(self, text = '', position_offset = (0, 0)):
-        if isinstance(self.FPS_image, type(None)):
-            # Without copy() method, images would be linked, meaning that modifying one image would also alter the other
-            self.FPS_image = np.copy(self.resized_image)
+        self._ensure_fps_image()
 
         cv2.putText(self.FPS_image, text, tuple(a + b for a, b in zip(CONST.TEXT_PARAMS['position'], position_offset)),
             cv2.FONT_HERSHEY_SIMPLEX, CONST.TEXT_PARAMS['font_scale'], CONST.TEXT_PARAMS['font_color'], 
@@ -102,9 +108,6 @@ class Image_Processing():
     # Draw the pressed button in the switch controller image
     def draw_button(self, button = ''):
         if not isinstance(button, str): return
-        if isinstance(self.FPS_image, type(None)):
-            # Without copy() method, images would be linked, meaning that modifying one image would also alter the other
-            self.FPS_image = np.copy(self.resized_image)
 
         self.FPS_image = np.copy(self.resized_image)
         button_coordinates = {
@@ -137,24 +140,35 @@ class Image_Processing():
 
     #######################################################################################################################
 
-    # Return if all the pixels of the specifiead row are of the specified color
-    def check_multiple_pixel_colors(self, start, end, color):
-        if isinstance(self.FPS_image, type(None)):
-            # Without copy() method, images would be linked, meaning that modifying one image would also alter the other
-            self.FPS_image = np.copy(self.resized_image)
+    def check_column_pixel_colors(self, position: Tuple[int, int], column_height: int, color: Tuple[int, int, int], threshold: int = CONST.PIXEL_COLOR_DIFF_THRESHOLD):
+        """
+        Check if all pixels in a specified column are of the specified color.
+
+        Args:
+            position (tuple): The starting position (x, y) of the column.
+            column_height (int): The height of the column to check.
+            color (tuple): The color to check against.
+            threshold (int): The maximum difference allowed between the pixel color and the specified color.
+
+        Returns:
+            bool: True if all pixels match the specified color, False otherwise.
+        """
+        self._ensure_fps_image()
 
         match_pixels = True
-        for index in range(start[1], end[1]):
-            # if all(self.resized_image[-index][start[0]] == color): continue
-            differences = [abs(self.resized_image[-index][start[0]][color_index] - color[color_index])
+        for row_index in range(position[1], position[1] + column_height):
+            differences = [abs(self.resized_image[-row_index][position[0]][color_index] - color[color_index])
                 for color_index in range(3)]
-            if all(difference <= CONST.PIXEL_COLOR_DIFF_THRESHOLD for difference in differences): continue
+
             # If one False is found, there is no need to check the other pixels
-            else: match_pixels = False; break
+            if not all(difference <= threshold for difference in differences):
+                match_pixels = False
+                break
 
         # Color all the pixels that are being checked
         if CONST.TESTING:
-            for index in range(start[1], end[1]): self.FPS_image[-index][start[0]] = CONST.TESTING_COLOR
+            for row_index in range(position[1], position[1] + column_height):
+                self.FPS_image[-row_index][position[0]] = CONST.TESTING_COLOR
 
         return match_pixels
 
@@ -316,10 +330,10 @@ if __name__ == "__main__":
         # cv2.circle(image.original_image, (20, 20), 9, CONST.PRESSED_BUTTON_COLOR, -1)
         # cv2.rectangle(image.resized_image, (50, 333), (670, 365), (255, 255, 0), 1)
         # print(image.recognize_pokemon())
-        # print(image.check_multiple_pixel_colors(
-        #     [int(CONST.MAIN_FRAME_SIZE[0] // 16 * 13), int(CONST.MAIN_FRAME_SIZE[1] // 16 * 4)],
-        #     [int(CONST.MAIN_FRAME_SIZE[0] // 16 * 13), int(CONST.MAIN_FRAME_SIZE[1] // 16 * 5)],
-        #     CONST.SELECTION_BOX_LINE['color']
+        # print(image.check_column_pixel_colors(
+        #     (int(CONST.MAIN_FRAME_SIZE[0] // 16 * 13), int(CONST.MAIN_FRAME_SIZE[1] // 16 * 4)),
+        #     CONST.COLOR_SCREEN_CHECK['column_height'],
+        #     CONST.COLOR_SCREEN_CHECK['white_color']
         # ))
 
         print(COLOR_str.PRESS_KEY_TO_INSTRUCTION
@@ -546,7 +560,7 @@ if __name__ == "__main__":
 
         index = 0
         cached_index = -1
-        pause = False
+        pause = True # Start paused; if not, when the dialog shows up, multiple images are already processed
         second_text_position = [CONST.TEXT_PARAMS['position'][0], CONST.TEXT_PARAMS['position'][1] + 20]
 
         while index < len(images):

--- a/Requirements.txt
+++ b/Requirements.txt
@@ -1,12 +1,14 @@
+setuptools==75.5.0
+wheel==0.45.0
 numpy==1.24.4
 nxbt==0.1.4
-opencv_python==4.5.3.56
+opencv_python==4.5.5.64
 Pillow==10.4.0
-PyAutoGUI==0.9.53
+PyAutoGUI==0.9.54
 pynput==1.7.1
 cllist==1.1.0
 llist==0.7.1
-pytesseract==0.3.10
+pytesseract==0.3.13
 playsound3==2.4.0
 PyQt5==5.14.1
 requests==2.32.3


### PR DESCRIPTION
Compared to the previous PR this one fixes and improves the is_life_box_visible method

--- 

Rename is_load_fight_white_screen_visible to is_white_screen_visible

Introduce is_bdsp_loading_screen

Check if the image matches the BDSP loading screen by verifying specific color positions.

BDSP loading screen has a black background.
The top left may have the Nintendo logo.
The bottom right may have the Nintendo Switch logo or the Pokémon starters icons.
The center may have the Nintendo copyright texts.

4 positions are checked: top_right, center_left, center_right, bottom_left

Simplify check_multiple_pixel_colors and rename it to check_column_pixel_colors

It takes in parameter a position and a column height instead of 2 positions

Improve is_text_box_visible by checking 3 more positions: top_right, top_left, center

A PR on the tests is available here: https://github.com/Dinones/Unit-Tests/pull/4